### PR TITLE
修复坐标系相关的问题

### DIFF
--- a/danmaku_recorder/recorder_imgui.lua
+++ b/danmaku_recorder/recorder_imgui.lua
@@ -306,6 +306,7 @@ end
 
 function recorder_imgui:render()
     if self.show_capture or self.set_capture_status == "capturing" then
+        SetViewMode("ui")
         local l_color = lstg.Color(self.highlight_color[4] * 255, self.highlight_color[1] * 255, self.highlight_color[2] * 255, self.highlight_color[3] * 255)
         lstg.SetImageState("white", "mul+add", l_color)
         local capture_area = recorder:get_capture_area()
@@ -315,6 +316,7 @@ function recorder_imgui:render()
                 capture_area.r, capture_area.t, 0.5,
                 capture_area.r, capture_area.b, 0.5
             )
+        SetViewMode("world") -- 恢复
     end
 end
 

--- a/register_event.lua
+++ b/register_event.lua
@@ -29,7 +29,6 @@ if event_dispatcher then
     end)
     event_dispatcher:RegisterEvent("GameState.AfterObjRender", "recorder_end_capture", 0, function ()
         recorder:end_capture()
-        SetViewMode("ui")
         recorder:draw_capture_content()
     end)
 
@@ -44,7 +43,6 @@ if event_dispatcher then
 
     if config.use_imgui then
         event_dispatcher:RegisterEvent("GameState.AfterRender", "recorder_imgui_render", -2, function ()
-            SetViewMode("ui")
             recorder_imgui:render()
         end)
     end


### PR DESCRIPTION
1. 全屏渲染目标绘制时应该用窗口坐标系而不是ui坐标系
2. 截取全屏渲染目标到GIF输出渲染目标时，应该使用修改后的 ui坐标系（忽略screen.dx、screen.dy）